### PR TITLE
(fix): Stop encoding OCR images as query parameters

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -1,2 +1,5 @@
 # Specify files that shouldn't be modified by Fern
 README.md
+
+# Temporary fix for mistakenly encoding images as query parameters.
+ocr.go

--- a/ocr.go
+++ b/ocr.go
@@ -14,9 +14,9 @@ type RunOcrSync struct {
 	// When using the Entity vendor network, specify the entity to use if. EntityId on an auth token will take precedence over this parameter.
 	EntityID *EntityID `json:"-" url:"entityId,omitempty"`
 	// MIME type of the image. Supported types are image/png, image/jpeg, and application/pdf.
-	MimeType string `json:"mimeType" url:"mimeType"`
+	MimeType string `json:"mimeType" url:"-"`
 	// Base64 encoded image or PDF. PNG, JPG, and PDF are supported. 10MB max.
-	Image string `json:"image" url:"image"`
+	Image string `json:"image" url:"-"`
 }
 
 type RunOcrAsync struct {

--- a/ocr.go
+++ b/ocr.go
@@ -25,9 +25,9 @@ type RunOcrAsync struct {
 	// When using the Entity vendor network, specify the entity to use if. EntityId on an auth token will take precedence over this parameter.
 	EntityID *EntityID `json:"-" url:"entityId,omitempty"`
 	// MIME type of the image. Supported types are image/png, image/jpeg, and application/pdf.
-	MimeType string `json:"mimeType" url:"mimeType"`
+	MimeType string `json:"mimeType" url:"-"`
 	// Base64 encoded image or PDF. PNG, JPG, and PDF are supported. 10MB max.
-	Image string `json:"image" url:"image"`
+	Image string `json:"image" url:"-"`
 }
 
 type VendorNetwork string


### PR DESCRIPTION
This fixes the `url` tag in the `RunOcrSync` request object to prevent the image and mime type from being encoded as query parameters.