### PR TITLE
:herb: Restore .fernignore

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -1,5 +1,2 @@
 # Specify files that shouldn't be modified by Fern
 README.md
-
-# Temporary fix for mistakenly encoding images as query parameters.
-ocr.go


### PR DESCRIPTION
This restores the `.fernignore` file back to its previous state so that this repository can receive a fresh generation.